### PR TITLE
Optimize compile map

### DIFF
--- a/MapAnalyzer/Debugger.py
+++ b/MapAnalyzer/Debugger.py
@@ -34,7 +34,7 @@ class LogFilter:
 
     def __call__(self, record: Dict[str, Any]) -> bool:
         levelno = logger.level(self.level).no
-        if 'sc2.' not in record["name"].lower():
+        if "sc2." not in record["name"].lower():
             return record["level"].no >= levelno
         return False
 
@@ -47,8 +47,8 @@ class MapAnalyzerDebugger:
     def __init__(self, map_data: "MapData", loglevel: str = "ERROR") -> None:
         self.map_data = map_data
         self.warnings = warnings
-        self.warnings.filterwarnings('ignore', category=DeprecationWarning)
-        self.warnings.filterwarnings('ignore', category=RuntimeWarning)
+        self.warnings.filterwarnings("ignore", category=DeprecationWarning)
+        self.warnings.filterwarnings("ignore", category=RuntimeWarning)
         self.local_log_filter = LocalLogFilter(module_name=LOG_MODULE, level=loglevel)
         self.log_format = LOG_FORMAT
         self.log_filter = LogFilter(level=loglevel)
@@ -57,47 +57,56 @@ class MapAnalyzerDebugger:
     @staticmethod
     def scatter(*args, **kwargs):
         import matplotlib.pyplot as plt
+
         plt.scatter(*args, **kwargs)
 
     @staticmethod
     def show():
         import matplotlib.pyplot as plt
+
         plt.show()
 
     @staticmethod
     def close():
         import matplotlib.pyplot as plt
-        plt.close(fig='all')
+
+        plt.close(fig="all")
 
     @staticmethod
     def save(filename: str) -> bool:
 
         for i in inspect.stack():
-            if 'test_suite.py' in str(i):
+            if "test_suite.py" in str(i):
                 logger.info(f"Skipping save operation on test runs")
                 logger.debug(f"index = {inspect.stack().index(i)}  {i}")
                 return True
         import matplotlib.pyplot as plt
+
         full_path = os.path.join(os.path.abspath("."), f"{filename}")
         plt.savefig(f"{filename}.png")
         logger.debug(f"Plot Saved to {full_path}")
 
-    def plot_regions(self,
-                     fontdict: Dict[str, Union[str, int]]) -> None:
+    def plot_regions(self, fontdict: Dict[str, Union[str, int]]) -> None:
         """"""
         import matplotlib.pyplot as plt
+
         for lbl, reg in self.map_data.regions.items():
             c = COLORS[lbl]
-            fontdict["color"] = 'black'
-            fontdict["backgroundcolor"] = 'black'
+            fontdict["color"] = "black"
+            fontdict["backgroundcolor"] = "black"
             # if c == 'black':
             #     fontdict["backgroundcolor"] = 'white'
             plt.text(
-                    reg.center[0],
-                    reg.center[1],
-                    reg.label,
-                    bbox=dict(fill=True, alpha=0.9, edgecolor=fontdict["backgroundcolor"], linewidth=2),
-                    fontdict=fontdict,
+                reg.center[0],
+                reg.center[1],
+                reg.label,
+                bbox=dict(
+                    fill=True,
+                    alpha=0.9,
+                    edgecolor=fontdict["backgroundcolor"],
+                    linewidth=2,
+                ),
+                fontdict=fontdict,
             )
             # random color for each perimeter
             x, y = zip(*reg.perimeter_points)
@@ -122,16 +131,17 @@ class MapAnalyzerDebugger:
         # todo: account for gold minerals and rich gas
         """
         import matplotlib.pyplot as plt
+
         for mfield in self.map_data.mineral_fields:
             plt.scatter(mfield.position[0], mfield.position[1], color="blue")
         for gasgeyser in self.map_data.normal_geysers:
             plt.scatter(
-                    gasgeyser.position[0],
-                    gasgeyser.position[1],
-                    color="yellow",
-                    marker=r"$\spadesuit$",
-                    s=500,
-                    edgecolors="g",
+                gasgeyser.position[0],
+                gasgeyser.position[1],
+                color="yellow",
+                marker=r"$\spadesuit$",
+                s=500,
+                edgecolors="g",
             )
 
     def plot_chokes(self) -> None:
@@ -139,49 +149,88 @@ class MapAnalyzerDebugger:
         compute Chokes
         """
         import matplotlib.pyplot as plt
+
         for choke in self.map_data.map_chokes:
             x, y = zip(*choke.points)
             cm = choke.center
             if choke.is_ramp:
                 fontdict = {"family": "serif", "weight": "bold", "size": 15}
-                plt.text(cm[0], cm[1], f"R<{[r.label for r in choke.regions]}>", fontdict=fontdict,
-                         bbox=dict(fill=True, alpha=0.4, edgecolor="cyan", linewidth=8))
+                plt.text(
+                    cm[0],
+                    cm[1],
+                    f"R<{[r.label for r in choke.regions]}>",
+                    fontdict=fontdict,
+                    bbox=dict(fill=True, alpha=0.4, edgecolor="cyan", linewidth=8),
+                )
                 plt.scatter(x, y, color="w")
             elif choke.is_vision_blocker:
 
                 fontdict = {"family": "serif", "size": 10}
-                plt.text(cm[0], cm[1], f"VB<>", fontdict=fontdict,
-                         bbox=dict(fill=True, alpha=0.3, edgecolor="red", linewidth=2))
-                plt.scatter(x, y, marker=r"$\heartsuit$", s=100, edgecolors="b", alpha=0.3)
+                plt.text(
+                    cm[0],
+                    cm[1],
+                    f"VB<>",
+                    fontdict=fontdict,
+                    bbox=dict(fill=True, alpha=0.3, edgecolor="red", linewidth=2),
+                )
+                plt.scatter(
+                    x, y, marker=r"$\heartsuit$", s=100, edgecolors="b", alpha=0.3
+                )
 
             else:
                 fontdict = {"family": "serif", "size": 10}
-                plt.text(cm[0], cm[1], f"C<{choke.id}>", fontdict=fontdict,
-                         bbox=dict(fill=True, alpha=0.3, edgecolor="red", linewidth=2))
-                plt.scatter(x, y, marker=r"$\heartsuit$", s=100, edgecolors="r", alpha=0.3)
+                plt.text(
+                    cm[0],
+                    cm[1],
+                    f"C<{choke.id}>",
+                    fontdict=fontdict,
+                    bbox=dict(fill=True, alpha=0.3, edgecolor="red", linewidth=2),
+                )
+                plt.scatter(
+                    x, y, marker=r"$\heartsuit$", s=100, edgecolors="r", alpha=0.3
+                )
             walls = [choke.side_a, choke.side_b]
             x, y = zip(*walls)
             fontdict = {"family": "serif", "size": 5}
-            if 'unregistered' not in str(choke.id).lower():
-                plt.text(choke.side_a[0], choke.side_a[1], f"C<{choke.id}sA>", fontdict=fontdict,
-                         bbox=dict(fill=True, alpha=0.5, edgecolor="green", linewidth=2))
-                plt.text(choke.side_b[0], choke.side_b[1], f"C<{choke.id}sB>", fontdict=fontdict,
-                         bbox=dict(fill=True, alpha=0.5, edgecolor="red", linewidth=2))
+            if "unregistered" not in str(choke.id).lower():
+                plt.text(
+                    choke.side_a[0],
+                    choke.side_a[1],
+                    f"C<{choke.id}sA>",
+                    fontdict=fontdict,
+                    bbox=dict(fill=True, alpha=0.5, edgecolor="green", linewidth=2),
+                )
+                plt.text(
+                    choke.side_b[0],
+                    choke.side_b[1],
+                    f"C<{choke.id}sB>",
+                    fontdict=fontdict,
+                    bbox=dict(fill=True, alpha=0.5, edgecolor="red", linewidth=2),
+                )
             else:
-                plt.text(choke.side_a[0], choke.side_a[1], f"sA>", fontdict=fontdict,
-                         bbox=dict(fill=True, alpha=0.5, edgecolor="green", linewidth=2))
-                plt.text(choke.side_b[0], choke.side_b[1], f"sB>", fontdict=fontdict,
-                         bbox=dict(fill=True, alpha=0.5, edgecolor="red", linewidth=2))
+                plt.text(
+                    choke.side_a[0],
+                    choke.side_a[1],
+                    f"sA>",
+                    fontdict=fontdict,
+                    bbox=dict(fill=True, alpha=0.5, edgecolor="green", linewidth=2),
+                )
+                plt.text(
+                    choke.side_b[0],
+                    choke.side_b[1],
+                    f"sB>",
+                    fontdict=fontdict,
+                    bbox=dict(fill=True, alpha=0.5, edgecolor="red", linewidth=2),
+                )
             plt.scatter(x, y, marker=r"$\spadesuit$", s=50, edgecolors="b", alpha=0.5)
 
     def plot_overlord_spots(self):
         import matplotlib.pyplot as plt
+
         for spot in self.map_data.overlord_spots:
             plt.scatter(spot[0], spot[1], marker="X", color="black")
 
-    def plot_map(
-            self, fontdict: dict = None, figsize: int = 20
-    ) -> None:
+    def plot_map(self, fontdict: dict = None, figsize: int = 20) -> None:
         """
 
         Plot map
@@ -191,6 +240,7 @@ class MapAnalyzerDebugger:
         if not fontdict:
             fontdict = {"family": "serif", "weight": "bold", "size": 25}
         import matplotlib.pyplot as plt
+
         plt.figure(figsize=(figsize, figsize))
         self.plot_regions(fontdict=fontdict)
         # some maps has no vision blockers
@@ -202,7 +252,9 @@ class MapAnalyzerDebugger:
 
         plt.style.use("ggplot")
         plt.imshow(self.map_data.region_grid.astype(float), origin="lower")
-        plt.imshow(self.map_data.terrain_height, alpha=1, origin="lower", cmap="terrain")
+        plt.imshow(
+            self.map_data.terrain_height, alpha=1, origin="lower", cmap="terrain"
+        )
         nonpathable_indices = np.where(self.map_data.path_arr == 0)
         nonpathable_indices_stacked = np.column_stack(
             (nonpathable_indices[1], nonpathable_indices[0])
@@ -218,17 +270,20 @@ class MapAnalyzerDebugger:
             tick.label1.set_fontweight("bold")
         plt.grid()
 
-
-    def plot_influenced_path(self, start: Union[Tuple[float, float], Point2],
-                               goal: Union[Tuple[float, float], Point2],
-                               weight_array: ndarray,
-                               large: bool = False,
-                               smoothing: bool = False,
-                               name: Optional[str] = None,
-                               fontdict: dict = None) -> None:
+    def plot_influenced_path(
+        self,
+        start: Union[Tuple[float, float], Point2],
+        goal: Union[Tuple[float, float], Point2],
+        weight_array: ndarray,
+        large: bool = False,
+        smoothing: bool = False,
+        name: Optional[str] = None,
+        fontdict: dict = None,
+    ) -> None:
         import matplotlib.pyplot as plt
         from mpl_toolkits.axes_grid1 import make_axes_locatable
         from matplotlib.cm import ScalarMappable
+
         if not fontdict:
             fontdict = {"family": "serif", "weight": "bold", "size": 20}
         plt.style.use(["ggplot", "bmh"])
@@ -236,17 +291,15 @@ class MapAnalyzerDebugger:
         if name is None:
             name = self.map_data.map_name
         arr = weight_array.copy()
-        path = self.map_data.pathfind(start, goal,
-                                        grid=arr,
-                                        large=large,
-                                        smoothing=smoothing,
-                                        sensitivity=1)
+        path = self.map_data.pathfind(
+            start, goal, grid=arr, large=large, smoothing=smoothing, sensitivity=1
+        )
         ax: plt.Axes = plt.subplot(1, 1, 1)
         if path is not None:
             path = np.flipud(path)  # for plot align
             logger.info("Found")
             x, y = zip(*path)
-            ax.scatter(x, y, s=3, c='green')
+            ax.scatter(x, y, s=3, c="green")
         else:
             logger.info("Not Found")
 
@@ -257,7 +310,7 @@ class MapAnalyzerDebugger:
         ax.text(start[0], start[1], f"Start {start}")
         ax.text(goal[0], goal[1], f"Goal {goal}")
         ax.imshow(self.map_data.path_arr, alpha=0.5, origin=org)
-        ax.imshow(self.map_data.terrain_height, alpha=0.5, origin=org, cmap='bone')
+        ax.imshow(self.map_data.terrain_height, alpha=0.5, origin=org, cmap="bone")
         arr = np.where(arr == np.inf, 0, arr).T
         ax.imshow(arr, origin=org, alpha=0.3, cmap=influence_cmap)
         divider = make_axes_locatable(ax)
@@ -266,20 +319,24 @@ class MapAnalyzerDebugger:
         sc.set_array(arr)
         sc.autoscale()
         cbar = plt.colorbar(sc, cax=cax)
-        cbar.ax.set_ylabel('Pathing Cost', rotation=270, labelpad=25, fontdict=fontdict)
-        plt.title(f"{name}", fontdict=fontdict, loc='right')
+        cbar.ax.set_ylabel("Pathing Cost", rotation=270, labelpad=25, fontdict=fontdict)
+        plt.title(f"{name}", fontdict=fontdict, loc="right")
         plt.grid()
 
-    def plot_influenced_path_nydus(self, start: Union[Tuple[float, float], Point2],
-                                   goal: Union[Tuple[float, float], Point2],
-                                   weight_array: ndarray,
-                                   large: bool = False,
-                                   smoothing: bool = False,
-                                   name: Optional[str] = None,
-                                   fontdict: dict = None) -> None:
+    def plot_influenced_path_nydus(
+        self,
+        start: Union[Tuple[float, float], Point2],
+        goal: Union[Tuple[float, float], Point2],
+        weight_array: ndarray,
+        large: bool = False,
+        smoothing: bool = False,
+        name: Optional[str] = None,
+        fontdict: dict = None,
+    ) -> None:
         import matplotlib.pyplot as plt
         from mpl_toolkits.axes_grid1 import make_axes_locatable
         from matplotlib.cm import ScalarMappable
+
         if not fontdict:
             fontdict = {"family": "serif", "weight": "bold", "size": 20}
         plt.style.use(["ggplot", "bmh"])
@@ -287,18 +344,16 @@ class MapAnalyzerDebugger:
         if name is None:
             name = self.map_data.map_name
         arr = weight_array.copy()
-        paths = self.map_data.pathfind_with_nyduses(start, goal,
-                                                    grid=arr,
-                                                    large=large,
-                                                    smoothing=smoothing,
-                                                    sensitivity=1)
+        paths = self.map_data.pathfind_with_nyduses(
+            start, goal, grid=arr, large=large, smoothing=smoothing, sensitivity=1
+        )
         ax: plt.Axes = plt.subplot(1, 1, 1)
         if paths is not None:
             for i in range(len(paths[0])):
                 path = np.flipud(paths[0][i])  # for plot align
                 logger.info("Found")
                 x, y = zip(*path)
-                ax.scatter(x, y, s=3, c='green')
+                ax.scatter(x, y, s=3, c="green")
         else:
             logger.info("Not Found")
 
@@ -309,7 +364,7 @@ class MapAnalyzerDebugger:
         ax.text(start[0], start[1], f"Start {start}")
         ax.text(goal[0], goal[1], f"Goal {goal}")
         ax.imshow(self.map_data.path_arr, alpha=0.5, origin=org)
-        ax.imshow(self.map_data.terrain_height, alpha=0.5, origin=org, cmap='bone')
+        ax.imshow(self.map_data.terrain_height, alpha=0.5, origin=org, cmap="bone")
         arr = np.where(arr == np.inf, 0, arr).T
         ax.imshow(arr, origin=org, alpha=0.3, cmap=influence_cmap)
         divider = make_axes_locatable(ax)
@@ -318,17 +373,19 @@ class MapAnalyzerDebugger:
         sc.set_array(arr)
         sc.autoscale()
         cbar = plt.colorbar(sc, cax=cax)
-        cbar.ax.set_ylabel('Pathing Cost', rotation=270, labelpad=25, fontdict=fontdict)
-        plt.title(f"{name}", fontdict=fontdict, loc='right')
+        cbar.ax.set_ylabel("Pathing Cost", rotation=270, labelpad=25, fontdict=fontdict)
+        plt.title(f"{name}", fontdict=fontdict, loc="right")
         plt.grid()
 
     @staticmethod
-    def draw_influence_in_game(bot: BotAI,
-                               grid: np.ndarray,
-                               lower_threshold: int,
-                               upper_threshold: int,
-                               color: Tuple[int, int, int],
-                               size: int) -> None:
+    def draw_influence_in_game(
+        bot: BotAI,
+        grid: np.ndarray,
+        lower_threshold: int,
+        upper_threshold: int,
+        color: Tuple[int, int, int],
+        size: int,
+    ) -> None:
         height: float = bot.get_terrain_z_height(bot.start_location)
         for x, y in zip(*np.where((grid > lower_threshold) & (grid < upper_threshold))):
             pos: Point3 = Point3((x, y, height))

--- a/MapAnalyzer/MapData.py
+++ b/MapAnalyzer/MapData.py
@@ -885,7 +885,8 @@ class MapData:
         # some maps has no vision blockers
         if len(vb_points):
             vision_blockers_indices = self.points_to_indices(vb_points)
-            vision_blockers_array = np.zeros(self.region_grid.shape, dtype="int")
+            rows, cols = self.path_arr.shape
+            vision_blockers_array = np.zeros((cols, rows), dtype="int")
             vision_blockers_array[vision_blockers_indices] = 1
             vb_labeled_array, vb_num_features = ndlabel(vision_blockers_array)
             self.vision_blockers_grid = vb_labeled_array
@@ -938,7 +939,7 @@ class MapData:
         # compute VisionBlockerArea
 
         for i in range(len(self.vision_blockers_labels)):
-            vb_arr = np.where(self.vision_blockers_grid.T == i, 1, 0)
+            vb_arr = np.where(self.vision_blockers_grid == i, 1, 0)
             vba = VisionBlockerArea(map_data=self, array=vb_arr)
             if vba.area <= 200:
                 self.map_vision_blockers.append(vba)

--- a/MapAnalyzer/MapData.py
+++ b/MapAnalyzer/MapData.py
@@ -2,7 +2,6 @@ import math
 import time
 from itertools import chain
 from functools import lru_cache
-from os import mkdir, path
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
@@ -944,11 +943,6 @@ class MapData:
             vba = VisionBlockerArea(map_data=self, array=vb_arr)
             if vba.area <= 200:
                 self.map_vision_blockers.append(vba)
-                areas = self.where_all(vba.center)
-                if len(areas) > 0:
-                    for area in areas:
-                        if area is not vba:
-                            vba.areas.append(area)
             else:
                 self.polygons.pop(self.polygons.index(vba))
 

--- a/MapAnalyzer/MapData.py
+++ b/MapAnalyzer/MapData.py
@@ -2,6 +2,7 @@ import math
 import time
 from itertools import chain
 from functools import lru_cache
+from os import mkdir, path
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
@@ -943,6 +944,11 @@ class MapData:
             vba = VisionBlockerArea(map_data=self, array=vb_arr)
             if vba.area <= 200:
                 self.map_vision_blockers.append(vba)
+                areas = self.where_all(vba.center)
+                if len(areas) > 0:
+                    for area in areas:
+                        if area is not vba:
+                            vba.areas.append(area)
             else:
                 self.polygons.pop(self.polygons.index(vba))
 

--- a/MapAnalyzer/MapData.py
+++ b/MapAnalyzer/MapData.py
@@ -90,7 +90,7 @@ class MapData:
         self.map_ramps: list = []  # set later on compile
         self.map_vision_blockers: list = []  # set later on compile
         self.vision_blockers_labels: list = []  # set later on compile
-        self.vision_blockers_grid: list = []  # set later on compile
+        self.vision_blockers_grid: Optional[ndarray] = None  # set later on compile
         self.overlord_spots: list = []
         self.resource_blockers = [
             Point2((m.position[0], m.position[1]))
@@ -574,7 +574,8 @@ class MapData:
                 Will handle safely(by ignoring) points that are ``out of bounds``, without warning
         """
         rows, cols = self.path_arr.shape
-        arr = np.zeros((rows, cols), dtype=np.uint8)
+        # transpose so we can index into it with x, y instead of y, x
+        arr = np.zeros((cols, rows), dtype=np.uint8)
         if isinstance(points, set):
             points = list(points)
 
@@ -903,10 +904,7 @@ class MapData:
             )
         )
         for i, poly in enumerate(self.polygons):
-            if isinstance(poly, Region):
-                self.extended_array_matrix[i] = poly.extended_array
-            else:
-                self.extended_array_matrix[i] = poly.extended_array.T
+            self.extended_array_matrix[i] = poly.extended_array
 
         for poly in self.polygons:
             poly_in_areas: np.ndarray = (
@@ -940,7 +938,7 @@ class MapData:
         # compute VisionBlockerArea
 
         for i in range(len(self.vision_blockers_labels)):
-            vb_arr = np.where(self.vision_blockers_grid == i, 1, 0)
+            vb_arr = np.where(self.vision_blockers_grid.T == i, 1, 0)
             vba = VisionBlockerArea(map_data=self, array=vb_arr)
             if vba.area <= 200:
                 self.map_vision_blockers.append(vba)

--- a/MapAnalyzer/Pather.py
+++ b/MapAnalyzer/Pather.py
@@ -15,10 +15,10 @@ from .destructibles import *
 
 if TYPE_CHECKING:
     from MapAnalyzer.MapData import MapData
-    
-    
+
+
 def _bounded_circle(center, radius, shape):
-    xx, yy = np.ogrid[:shape[0], :shape[1]]
+    xx, yy = np.ogrid[: shape[0], : shape[1]]
     circle = (xx - center[0]) ** 2 + (yy - center[1]) ** 2
     return np.nonzero(circle <= radius ** 2)
 
@@ -55,7 +55,9 @@ class MapAnalyzerPather:
         # need to consider the placement arr because our base minerals, geysers and townhall
         # are not pathable in the pathing grid
         # we manage those manually so they are accurate through the game
-        self.default_grid = np.fmax(self.map_data.path_arr, self.map_data.placement_arr).T
+        self.default_grid = np.fmax(
+            self.map_data.path_arr, self.map_data.placement_arr
+        ).T
 
         # Fixing platforms on Submarine which reapers can climb onto not being pathable
         # Don't use the entire name because we also use the modified maps
@@ -74,7 +76,10 @@ class MapAnalyzerPather:
         # that still exist
         for dest in self.map_data.bot.destructables:
             self.destructables_included[dest.position] = dest
-            if "unbuildable" not in dest.name.lower() and "acceleration" not in dest.name.lower():
+            if (
+                "unbuildable" not in dest.name.lower()
+                and "acceleration" not in dest.name.lower()
+            ):
                 change_destructable_status_in_grid(self.default_grid, dest, 0)
                 change_destructable_status_in_grid(self.default_grid_nodestr, dest, 1)
 
@@ -109,7 +114,9 @@ class MapAnalyzerPather:
                     connectivity_graph[region].append(connected_region)
         self.connectivity_graph = connectivity_graph
 
-    def find_all_paths(self, start: Region, goal: Region, path: Optional[List[Region]] = None) -> List[List[Region]]:
+    def find_all_paths(
+        self, start: Region, goal: Region, path: Optional[List[Region]] = None
+    ) -> List[List[Region]]:
         if path is None:
             path = []
         graph = self.connectivity_graph
@@ -126,13 +133,16 @@ class MapAnalyzerPather:
                     paths.append(newpath)
         return paths
 
-    def _add_non_pathables_ground(self, grid: ndarray, include_destructables: bool = True) -> ndarray:
+    def _add_non_pathables_ground(
+        self, grid: ndarray, include_destructables: bool = True
+    ) -> ndarray:
         ret_grid = grid.copy()
         nonpathables = self.map_data.bot.structures.not_flying
         nonpathables.extend(self.map_data.bot.enemy_structures.not_flying)
         nonpathables = nonpathables.filter(
             lambda x: (x.type_id != UnitTypeId.SUPPLYDEPOTLOWERED or x.is_active)
-                      and (x.type_id != UnitTypeId.CREEPTUMOR or not x.is_ready))
+            and (x.type_id != UnitTypeId.CREEPTUMOR or not x.is_ready)
+        )
 
         for obj in nonpathables:
             size = 1
@@ -179,7 +189,11 @@ class MapAnalyzerPather:
 
                 del self.minerals_included[mf_position]
 
-        if include_destructables and len(self.destructables_included) != self.map_data.bot.destructables.amount:
+        if (
+            include_destructables
+            and len(self.destructables_included)
+            != self.map_data.bot.destructables.amount
+        ):
             new_positions = set(d.position for d in self.map_data.bot.destructables)
             old_dest_positions = set(self.destructables_included)
             missing_positions = old_dest_positions - new_positions
@@ -193,7 +207,13 @@ class MapAnalyzerPather:
 
         return ret_grid
 
-    def find_eligible_point(self, point: Tuple[float, float], grid: np.ndarray, terrain_height: np.ndarray, max_distance: float) -> Optional[Tuple[int, int]]:
+    def find_eligible_point(
+        self,
+        point: Tuple[float, float],
+        grid: np.ndarray,
+        terrain_height: np.ndarray,
+        max_distance: float,
+    ) -> Optional[Tuple[int, int]]:
         """
         User may give a point that is in a nonpathable grid cell, for example inside a building or
         inside rocks. The desired behavior is to move the point a bit so for example we can start or finish
@@ -209,30 +229,42 @@ class MapAnalyzerPather:
             disk = tuple(draw_circle(point, max_distance, shape=grid.shape))
             # Using 8 for the threshold in case there is some variance on the same level
             # Proper levels have a height difference of 16
-            same_height_cond = np.logical_and(np.abs(terrain_height[disk] - target_height) < 8, grid[disk] < np.inf)
+            same_height_cond = np.logical_and(
+                np.abs(terrain_height[disk] - target_height) < 8, grid[disk] < np.inf
+            )
 
             if np.any(same_height_cond):
-                possible_points = np.column_stack((disk[0][same_height_cond], disk[1][same_height_cond]))
-                closest_point_index = np.argmin(np.sum((possible_points - point) ** 2, axis=1))
+                possible_points = np.column_stack(
+                    (disk[0][same_height_cond], disk[1][same_height_cond])
+                )
+                closest_point_index = np.argmin(
+                    np.sum((possible_points - point) ** 2, axis=1)
+                )
                 return tuple(possible_points[closest_point_index])
             else:
                 diff_height_cond = grid[disk] < np.inf
                 if np.any(diff_height_cond):
-                    possible_points = np.column_stack((disk[0][diff_height_cond], disk[1][diff_height_cond]))
-                    closest_point_index = np.argmin(np.sum((possible_points - point) ** 2, axis=1))
+                    possible_points = np.column_stack(
+                        (disk[0][diff_height_cond], disk[1][diff_height_cond])
+                    )
+                    closest_point_index = np.argmin(
+                        np.sum((possible_points - point) ** 2, axis=1)
+                    )
                     return tuple(possible_points[closest_point_index])
                 else:
                     return None
         return point
 
-    def lowest_cost_points_array(self, from_pos: tuple, radius: float, grid: np.ndarray) -> Optional[np.ndarray]:
+    def lowest_cost_points_array(
+        self, from_pos: tuple, radius: float, grid: np.ndarray
+    ) -> Optional[np.ndarray]:
         """For use with evaluations that use numpy arrays
-                example: # Closest point to unit furthest from target
-                        distances = cdist([[unitpos, targetpos]], lowest_points, "sqeuclidean")
-                        lowest_points[(distances[0] - distances[1]).argmin()]
-            - 140 µs per loop
+            example: # Closest point to unit furthest from target
+                    distances = cdist([[unitpos, targetpos]], lowest_points, "sqeuclidean")
+                    lowest_points[(distances[0] - distances[1]).argmin()]
+        - 140 µs per loop
         """
-        
+
         disk = tuple(draw_circle(from_pos, radius, shape=grid.shape))
         if len(disk[0]) == 0:
             return None
@@ -241,7 +273,9 @@ class MapAnalyzerPather:
         cond = grid[disk] == arrmin
         return np.column_stack((disk[0][cond], disk[1][cond]))
 
-    def find_lowest_cost_points(self, from_pos: Point2, radius: float, grid: np.ndarray) -> Optional[List[Point2]]:
+    def find_lowest_cost_points(
+        self, from_pos: Point2, radius: float, grid: np.ndarray
+    ) -> Optional[List[Point2]]:
         lowest = self.lowest_cost_points_array(from_pos, radius, grid)
 
         if lowest is None:
@@ -255,43 +289,62 @@ class MapAnalyzerPather:
         else:
             return self.default_grid_nodestr.copy()
 
-    def get_climber_grid(self, default_weight: float = 1, include_destructables: bool = True) -> ndarray:
-        """Grid for units like reaper / colossus """
+    def get_climber_grid(
+        self, default_weight: float = 1, include_destructables: bool = True
+    ) -> ndarray:
+        """Grid for units like reaper / colossus"""
         grid = self.get_base_pathing_grid(include_destructables)
         grid = np.where(self.map_data.c_ext_map.climber_grid != 0, 1, grid)
-        grid = self._add_non_pathables_ground(grid=grid, include_destructables=include_destructables)
+        grid = self._add_non_pathables_ground(
+            grid=grid, include_destructables=include_destructables
+        )
         grid = np.where(grid != 0, default_weight, np.inf).astype(np.float32)
         return grid
 
     def get_clean_air_grid(self, default_weight: float = 1) -> ndarray:
         clean_air_grid = np.zeros(shape=self.default_grid.shape).astype(np.float32)
         area = self.map_data.bot.game_info.playable_area
-        clean_air_grid[area.x:(area.x + area.width), area.y:(area.y + area.height)] = 1
+        clean_air_grid[
+            area.x : (area.x + area.width), area.y : (area.y + area.height)
+        ] = 1
         return np.where(clean_air_grid == 1, default_weight, np.inf).astype(np.float32)
 
     def get_air_vs_ground_grid(self, default_weight: float) -> ndarray:
-        grid = self.get_pyastar_grid(default_weight=default_weight, include_destructables=True)
+        grid = self.get_pyastar_grid(
+            default_weight=default_weight, include_destructables=True
+        )
         # set non pathable points inside map bounds to value 1
         area = self.map_data.bot.game_info.playable_area
         start_x = area.x
         end_x = area.x + area.width
         start_y = area.y
         end_y = area.y + area.height
-        grid[start_x:end_x, start_y:end_y] = np.where(grid[start_x:end_x, start_y:end_y] == np.inf, 1, default_weight)
+        grid[start_x:end_x, start_y:end_y] = np.where(
+            grid[start_x:end_x, start_y:end_y] == np.inf, 1, default_weight
+        )
 
         return grid
 
-    def get_pyastar_grid(self, default_weight: float = 1, include_destructables: bool = True) -> ndarray:
+    def get_pyastar_grid(
+        self, default_weight: float = 1, include_destructables: bool = True
+    ) -> ndarray:
         grid = self.get_base_pathing_grid(include_destructables)
-        grid = self._add_non_pathables_ground(grid=grid, include_destructables=include_destructables)
+        grid = self._add_non_pathables_ground(
+            grid=grid, include_destructables=include_destructables
+        )
 
         grid = np.where(grid != 0, default_weight, np.inf).astype(np.float32)
         return grid
 
-    def pathfind(self, start: Tuple[float, float], goal: Tuple[float, float], grid: Optional[ndarray] = None,
-                 large: bool = False,
-                 smoothing: bool = False,
-                 sensitivity: int = 1) -> Optional[List[Point2]]:
+    def pathfind(
+        self,
+        start: Tuple[float, float],
+        goal: Tuple[float, float],
+        grid: Optional[ndarray] = None,
+        large: bool = False,
+        smoothing: bool = False,
+        sensitivity: int = 1,
+    ) -> Optional[List[Point2]]:
         if grid is None:
             logger.warning("Using the default pyastar grid as no grid was provided.")
             grid = self.get_pyastar_grid()
@@ -327,11 +380,15 @@ class MapAnalyzerPather:
             logger.debug(f"No Path found s{start}, g{goal}")
             return None
 
-    def pathfind_with_nyduses(self, start: Tuple[float, float], goal: Tuple[float, float],
-                              grid: Optional[ndarray] = None,
-                              large: bool = False,
-                              smoothing: bool = False,
-                              sensitivity: int = 1) -> Optional[Tuple[List[List[Point2]], Optional[List[int]]]]:
+    def pathfind_with_nyduses(
+        self,
+        start: Tuple[float, float],
+        goal: Tuple[float, float],
+        grid: Optional[ndarray] = None,
+        large: bool = False,
+        smoothing: bool = False,
+        sensitivity: int = 1,
+    ) -> Optional[Tuple[List[List[Point2]], Optional[List[int]]]]:
         if grid is None:
             logger.warning("Using the default pyastar grid as no grid was provided.")
             grid = self.get_pyastar_grid()
@@ -349,12 +406,14 @@ class MapAnalyzerPather:
         if start is None or goal is None:
             return None
 
-        nydus_units = self.map_data.bot.structures.of_type([UnitTypeId.NYDUSNETWORK, UnitTypeId.NYDUSCANAL]).ready
+        nydus_units = self.map_data.bot.structures.of_type(
+            [UnitTypeId.NYDUSNETWORK, UnitTypeId.NYDUSCANAL]
+        ).ready
         nydus_positions = [nydus.position for nydus in nydus_units]
 
-        paths = astar_path_with_nyduses(grid, start, goal,
-                                        nydus_positions,
-                                        large, smoothing)
+        paths = astar_path_with_nyduses(
+            grid, start, goal, nydus_positions, large, smoothing
+        )
         if paths is not None:
             returned_path = []
             nydus_tags = None
@@ -373,11 +432,15 @@ class MapAnalyzerPather:
                 first_skipped_path.append(first_path[-1])
                 returned_path.append(first_skipped_path)
 
-                enter_nydus_unit = nydus_units.filter(lambda x: x.position.rounded == first_path[-1]).first
+                enter_nydus_unit = nydus_units.filter(
+                    lambda x: x.position.rounded == first_path[-1]
+                ).first
                 enter_nydus_tag = enter_nydus_unit.tag
 
                 second_path = list(map(Point2, paths[1]))
-                exit_nydus_unit = nydus_units.filter(lambda x: x.position.rounded == second_path[0]).first
+                exit_nydus_unit = nydus_units.filter(
+                    lambda x: x.position.rounded == second_path[0]
+                ).first
                 exit_nydus_tag = exit_nydus_unit.tag
                 nydus_tags = [enter_nydus_tag, exit_nydus_tag]
 

--- a/MapAnalyzer/Polygon.py
+++ b/MapAnalyzer/Polygon.py
@@ -319,13 +319,14 @@ class Polygon:
         return {Point2((p[0], p[1])) for p in self.perimeter}
 
     @property
-    def area(self) -> int:
+    @lru_cache()
+    # type hinting complains if ndarray is not here, but always returns a numpy.int32
+    def area(self) -> Union[int, np.ndarray]:
         """
-
         Sum of all points
 
         """
-        return len(self.points)
+        return np.sum(self.extended_array)
 
     def __repr__(self) -> str:
         return f"<Polygon[size={self.area}]: {self.areas}>"

--- a/MapAnalyzer/Polygon.py
+++ b/MapAnalyzer/Polygon.py
@@ -52,11 +52,15 @@ class Buildables:
         parr = self.polygon.map_data.points_to_numpy_array(self.polygon.points)
         # passing safe false to reduce the warnings,
         # which are irrelevant in this case
-        [self.polygon.map_data.add_cost(position=(unit.position.x, unit.position.y), radius=unit.radius * 0.9,
-                                        grid=parr,
-                                        safe=False)
-         for unit in
-         self.polygon.map_data.bot.all_units.not_flying]
+        [
+            self.polygon.map_data.add_cost(
+                position=(unit.position.x, unit.position.y),
+                radius=unit.radius * 0.9,
+                grid=parr,
+                safe=False,
+            )
+            for unit in self.polygon.map_data.bot.all_units.not_flying
+        ]
         buildable_indices = np.where(parr == 1)
         buildable_points = []
         _points = list(self.polygon.map_data.indices_to_points(buildable_indices))
@@ -130,6 +134,7 @@ class Polygon:
 
         """
         from MapAnalyzer.Region import Region
+
         if len(self.areas) > 0:
             return [r for r in self.areas if isinstance(r, Region)]
         return []
@@ -155,6 +160,7 @@ class Polygon:
 
         """
         import matplotlib.pyplot as plt
+
         plt.style.use("ggplot")
 
         plt.imshow(self.array, origin="lower")
@@ -184,7 +190,10 @@ class Polygon:
         from skimage.feature import corner_harris, corner_peaks
 
         array = corner_peaks(
-                corner_harris(self.array), min_distance=self.map_data.corner_distance, threshold_rel=0.01)
+            corner_harris(self.array),
+            min_distance=self.map_data.corner_distance,
+            threshold_rel=0.01,
+        )
         return array
 
     @property
@@ -210,7 +219,11 @@ class Polygon:
         :rtype: List[:class:`.Point2`]
 
         """
-        points = [Point2((int(p[0]), int(p[1]))) for p in self.corner_array if self.is_inside_point(Point2(p))]
+        points = [
+            Point2((int(p[0]), int(p[1])))
+            for p in self.corner_array
+            if self.is_inside_point(Point2(p))
+        ]
         return points
 
     @property
@@ -226,7 +239,9 @@ class Polygon:
 
         """
 
-        cm = self.map_data.closest_towards_point(points=list(self.points), target=center_of_mass(self.array))
+        cm = self.map_data.closest_towards_point(
+            points=list(self.points), target=center_of_mass(self.array)
+        )
         return cm
 
     def is_inside_point(self, point: Union[Point2, tuple]) -> bool:

--- a/MapAnalyzer/Region.py
+++ b/MapAnalyzer/Region.py
@@ -24,24 +24,24 @@ class Region(Polygon):
         But it will never share a point with another :class:`.Region`
 
     """
+
     def __init__(
-            self,
-            map_data: 'MapData',
-            array: np.ndarray,
-            label: int,
-            map_expansions: List[Point2],
+        self,
+        map_data: "MapData",
+        array: np.ndarray,
+        label: int,
+        map_expansions: List[Point2],
     ) -> None:
         super().__init__(map_data=map_data, array=array)
         self.label = label
         self.is_region = True
         self.bases = [
-                base
-                for base in map_expansions
-                if self.is_inside_point((base.rounded[0], base.rounded[1]))
+            base
+            for base in map_expansions
+            if self.is_inside_point((base.rounded[0], base.rounded[1]))
         ]  # will be set later by mapdata
         self.region_vision_blockers = []  # will be set later by mapdata
         self.region_vb = []
-
 
     @property
     def region_ramps(self) -> List[MDRamp]:
@@ -94,20 +94,22 @@ class Region(Polygon):
 
     def _plot_corners(self) -> None:
         import matplotlib.pyplot as plt
+
         plt.style.use("ggplot")
         for corner in self.corner_points:
             plt.scatter(corner[0], corner[1], marker="v", c="red", s=150)
 
     def _plot_ramps(self) -> None:
         import matplotlib.pyplot as plt
+
         plt.style.use("ggplot")
         for ramp in self.region_ramps:
             plt.text(
-                    # fixme make ramp attr compatible and not reversed
-                    ramp.top_center[0],
-                    ramp.top_center[1],
-                    f"R<{[r.label for r in ramp.regions]}>",
-                    bbox=dict(fill=True, alpha=0.3, edgecolor="cyan", linewidth=8),
+                # fixme make ramp attr compatible and not reversed
+                ramp.top_center[0],
+                ramp.top_center[1],
+                f"R<{[r.label for r in ramp.regions]}>",
+                bbox=dict(fill=True, alpha=0.3, edgecolor="cyan", linewidth=8),
             )
             # ramp.plot(testing=True)
             x, y = zip(*ramp.points)
@@ -128,7 +130,7 @@ class Region(Polygon):
         for mineral_field in self.map_data.mineral_fields:
             if self.is_inside_point(mineral_field.position.rounded):
                 plt.scatter(
-                        mineral_field.position[0], mineral_field.position[1], color="blue"
+                    mineral_field.position[0], mineral_field.position[1], color="blue"
                 )
 
     def _plot_geysers(self) -> None:
@@ -138,18 +140,18 @@ class Region(Polygon):
         for gasgeyser in self.map_data.normal_geysers:
             if self.is_inside_point(gasgeyser.position.rounded):
                 plt.scatter(
-                        gasgeyser.position[0],
-                        gasgeyser.position[1],
-                        color="yellow",
-                        marker=r"$\spadesuit$",
-                        s=500,
-                        edgecolors="g",
+                    gasgeyser.position[0],
+                    gasgeyser.position[1],
+                    color="yellow",
+                    marker=r"$\spadesuit$",
+                    s=500,
+                    edgecolors="g",
                 )
 
     def plot(self, self_only: bool = True, testing: bool = False) -> None:
         """
 
-            Debug Method plot
+        Debug Method plot
 
         """
         import matplotlib.pyplot as plt

--- a/MapAnalyzer/__init__.py
+++ b/MapAnalyzer/__init__.py
@@ -1,4 +1,3 @@
-
 # flake8: noqa
 from .MapData import MapData
 from .Polygon import Polygon
@@ -7,6 +6,6 @@ from .constructs import ChokeArea, MDRamp, VisionBlockerArea
 from pkg_resources import get_distribution, DistributionNotFound
 
 try:
-    __version__ = get_distribution('sc2mapanalyzer')
+    __version__ = get_distribution("sc2mapanalyzer")
 except DistributionNotFound:
-    __version__ = 'dev'
+    __version__ = "dev"

--- a/MapAnalyzer/cext/wrapper.py
+++ b/MapAnalyzer/cext/wrapper.py
@@ -1,9 +1,17 @@
 import numpy as np
 
 try:
-    from .mapanalyzerext import astar as ext_astar, astar_with_nydus as ext_astar_nydus, get_map_data as ext_get_map_data
+    from .mapanalyzerext import (
+        astar as ext_astar,
+        astar_with_nydus as ext_astar_nydus,
+        get_map_data as ext_get_map_data,
+    )
 except ImportError:
-    from mapanalyzerext import astar as ext_astar, astar_with_nydus as ext_astar_nydus, get_map_data as ext_get_map_data
+    from mapanalyzerext import (
+        astar as ext_astar,
+        astar_with_nydus as ext_astar_nydus,
+        get_map_data as ext_get_map_data,
+    )
 
 from typing import Optional, Tuple, Union, List, Set
 from sc2.position import Point2, Rect
@@ -20,6 +28,7 @@ class CMapChoke:
     min_length minimum distance between the sides of the choke
     id an integer to represent the choke
     """
+
     main_line: Tuple[Tuple[float, float], Tuple[float, float]]
     lines: List[Tuple[Tuple[int, int], Tuple[int, int]]]
     side1: List[Tuple[int, int]]
@@ -49,30 +58,41 @@ class CMapChoke:
 climber_grid_exceptions = {
     "DeathAura": [
         np.meshgrid(range(36, 49), range(118, 127)),
-        np.meshgrid(range(143, 154), range(61, 70))
+        np.meshgrid(range(143, 154), range(61, 70)),
     ]
 }
 
 
 def astar_path(
-        weights: np.ndarray,
-        start: Tuple[int, int],
-        goal: Tuple[int, int],
-        large: bool = False,
-        smoothing: bool = False) -> Union[np.ndarray, None]:
+    weights: np.ndarray,
+    start: Tuple[int, int],
+    goal: Tuple[int, int],
+    large: bool = False,
+    smoothing: bool = False,
+) -> Union[np.ndarray, None]:
     # For the heuristic to be valid, each move must have a positive cost.
     # Demand costs above 1 so floating point inaccuracies aren't a problem
     # when comparing costs
     if weights.min(axis=None) < 1:
-        raise ValueError("Minimum cost to move must be above or equal to 1, but got %f" % (
-            weights.min(axis=None)))
+        raise ValueError(
+            "Minimum cost to move must be above or equal to 1, but got %f"
+            % (weights.min(axis=None))
+        )
     # Ensure start is within bounds.
-    if (start[0] < 0 or start[0] >= weights.shape[0] or
-            start[1] < 0 or start[1] >= weights.shape[1]):
+    if (
+        start[0] < 0
+        or start[0] >= weights.shape[0]
+        or start[1] < 0
+        or start[1] >= weights.shape[1]
+    ):
         raise ValueError(f"Start of {start} lies outside grid.")
     # Ensure goal is within bounds.
-    if (goal[0] < 0 or goal[0] >= weights.shape[0] or
-            goal[1] < 0 or goal[1] >= weights.shape[1]):
+    if (
+        goal[0] < 0
+        or goal[0] >= weights.shape[0]
+        or goal[1] < 0
+        or goal[1] >= weights.shape[1]
+    ):
         raise ValueError(f"Goal of {goal} lies outside grid.")
 
     height, width = weights.shape
@@ -85,25 +105,38 @@ def astar_path(
 
     return path
 
-def astar_path_with_nyduses(weights: np.ndarray,
-        start: Tuple[int, int],
-        goal: Tuple[int, int],
-        nydus_positions: List[Point2],
-        large: bool = False,
-        smoothing: bool = False) -> Union[List[np.ndarray], None]:
+
+def astar_path_with_nyduses(
+    weights: np.ndarray,
+    start: Tuple[int, int],
+    goal: Tuple[int, int],
+    nydus_positions: List[Point2],
+    large: bool = False,
+    smoothing: bool = False,
+) -> Union[List[np.ndarray], None]:
     # For the heuristic to be valid, each move must have a positive cost.
     # Demand costs above 1 so floating point inaccuracies aren't a problem
     # when comparing costs
     if weights.min(axis=None) < 1:
-        raise ValueError("Minimum cost to move must be above or equal to 1, but got %f" % (
-            weights.min(axis=None)))
+        raise ValueError(
+            "Minimum cost to move must be above or equal to 1, but got %f"
+            % (weights.min(axis=None))
+        )
     # Ensure start is within bounds.
-    if (start[0] < 0 or start[0] >= weights.shape[0] or
-            start[1] < 0 or start[1] >= weights.shape[1]):
+    if (
+        start[0] < 0
+        or start[0] >= weights.shape[0]
+        or start[1] < 0
+        or start[1] >= weights.shape[1]
+    ):
         raise ValueError(f"Start of {start} lies outside grid.")
     # Ensure goal is within bounds.
-    if (goal[0] < 0 or goal[0] >= weights.shape[0] or
-            goal[1] < 0 or goal[1] >= weights.shape[1]):
+    if (
+        goal[0] < 0
+        or goal[0] >= weights.shape[0]
+        or goal[1] < 0
+        or goal[1] >= weights.shape[1]
+    ):
         raise ValueError(f"Goal of {goal} lies outside grid.")
 
     height, width = weights.shape
@@ -115,8 +148,16 @@ def astar_path_with_nyduses(weights: np.ndarray,
         nydus_idx = np.ravel_multi_index((int(pos.x), int(pos.y)), (height, width))
         nydus_array[index] = nydus_idx
 
-    path = ext_astar_nydus(weights.flatten(), height, width, nydus_array.flatten(),
-                           start_idx, goal_idx, large, smoothing)
+    path = ext_astar_nydus(
+        weights.flatten(),
+        height,
+        width,
+        nydus_array.flatten(),
+        start_idx,
+        goal_idx,
+        large,
+        smoothing,
+    )
 
     return path
 
@@ -126,7 +167,13 @@ class CMapInfo:
     overlord_spots: Optional[List[Point2]]
     chokes: List[CMapChoke]
 
-    def __init__(self, walkable_grid: np.ndarray, height_map: np.ndarray, playable_area: Rect, map_name: str):
+    def __init__(
+        self,
+        walkable_grid: np.ndarray,
+        height_map: np.ndarray,
+        playable_area: Rect,
+        map_name: str,
+    ):
         """
         walkable_grid and height_map are matrices of type uint8
         """
@@ -138,11 +185,9 @@ class CMapInfo:
         c_start_x = int(playable_area.y)
         c_end_x = int(playable_area.y + playable_area.height)
 
-        self.climber_grid, overlord_data, choke_data = self._get_map_data(walkable_grid, height_map,
-                                                                          c_start_y,
-                                                                          c_end_y,
-                                                                          c_start_x,
-                                                                          c_end_x)
+        self.climber_grid, overlord_data, choke_data = self._get_map_data(
+            walkable_grid, height_map, c_start_y, c_end_y, c_start_x, c_end_x
+        )
 
         # some maps may have places where the current method for building the climber grid isn't correct
         for map_exception in climber_grid_exceptions:
@@ -156,16 +201,28 @@ class CMapInfo:
         self.chokes = []
         id_counter = 0
         for c in choke_data:
-            self.chokes.append(CMapChoke(id_counter, c[0], c[1], c[2], c[3], c[4], c[5]))
+            self.chokes.append(
+                CMapChoke(id_counter, c[0], c[1], c[2], c[3], c[4], c[5])
+            )
             id_counter += 1
 
     @staticmethod
-    def _get_map_data(walkable_grid: np.ndarray, height_map: np.ndarray,
-                      start_y: int,
-                      end_y: int,
-                      start_x: int,
-                      end_x: int):
+    def _get_map_data(
+        walkable_grid: np.ndarray,
+        height_map: np.ndarray,
+        start_y: int,
+        end_y: int,
+        start_x: int,
+        end_x: int,
+    ):
         height, width = walkable_grid.shape
-        return ext_get_map_data(walkable_grid.flatten(), height_map.flatten(), height, width,
-                            start_y, end_y, start_x, end_x)
-
+        return ext_get_map_data(
+            walkable_grid.flatten(),
+            height_map.flatten(),
+            height,
+            width,
+            start_y,
+            end_y,
+            start_x,
+            end_x,
+        )

--- a/MapAnalyzer/constants.py
+++ b/MapAnalyzer/constants.py
@@ -7,30 +7,32 @@ NONPATHABLE_RADIUS_FACTOR = 0.8
 CORNER_MIN_DISTANCE = 3
 LOG_MODULE = "MapAnalyzer"
 COLORS = {
-        0 : "azure",
-        1 : 'black',
-        2 : 'red',
-        3 : 'green',
-        4 : 'blue',
-        5 : 'orange',
-        6 : 'saddlebrown',
-        7 : 'lime',
-        8 : 'navy',
-        9 : 'purple',
-        10: 'olive',
-        11: 'aquamarine',
-        12: 'indigo',
-        13: 'tan',
-        14: 'skyblue',
-        15: "wheat",
-        16: "azure",
-        17: "azure",
-        18: "azure",
-        19: "azure",
-        20: "azure"
+    0: "azure",
+    1: "black",
+    2: "red",
+    3: "green",
+    4: "blue",
+    5: "orange",
+    6: "saddlebrown",
+    7: "lime",
+    8: "navy",
+    9: "purple",
+    10: "olive",
+    11: "aquamarine",
+    12: "indigo",
+    13: "tan",
+    14: "skyblue",
+    15: "wheat",
+    16: "azure",
+    17: "azure",
+    18: "azure",
+    19: "azure",
+    20: "azure",
 }
-LOG_FORMAT = "<w><bold>{time:YY:MM:DD:HH:mm:ss}|" \
-             "<level>{level: <8}</level>|<green>{name: ^15}</green>|" \
-             "{function: ^15}|" \
-             "{line: >4}|" \
-             "<level> {level.icon} {message}</level></bold></w>"
+LOG_FORMAT = (
+    "<w><bold>{time:YY:MM:DD:HH:mm:ss}|"
+    "<level>{level: <8}</level>|<green>{name: ^15}</green>|"
+    "{function: ^15}|"
+    "{line: >4}|"
+    "<level> {level.icon} {message}</level></bold></w>"
+)

--- a/MapAnalyzer/constructs.py
+++ b/MapAnalyzer/constructs.py
@@ -160,28 +160,6 @@ class MDRamp(ChokeArea):
              Make this a private method
 
         """
-        from MapAnalyzer.Region import Region
-
-        for p in self.outer_perimeter_points:
-            areas = self.map_data.where_all(p)
-            for area in areas:
-                # edge case  = its a VisionBlockerArea (and also on the perimeter) so we grab the touching Regions
-                if isinstance(area, VisionBlockerArea):
-                    for sub_area in area.areas:
-                        # add it to our Areas
-                        if isinstance(sub_area, Region) and sub_area not in self.areas:
-                            self.areas.append(sub_area)
-                        # add ourselves to it's Areas
-                        if isinstance(sub_area, Region) and self not in sub_area.areas:
-                            sub_area.areas.append(self)
-
-                # standard case
-                if isinstance(area, Region) and area not in self.areas:
-                    self.areas.append(area)
-                    # add ourselves to the Region Area's
-                if isinstance(area, Region) and self not in area.areas:
-                    area.areas.append(self)
-
         if len(self.regions) < 2:
             region_list = list(self.map_data.regions.values())
             region_list.remove(self.regions[0])

--- a/MapAnalyzer/constructs.py
+++ b/MapAnalyzer/constructs.py
@@ -23,7 +23,7 @@ class ChokeArea(Polygon):
     def __init__(self, array: np.ndarray, map_data: "MapData") -> None:
         super().__init__(map_data=map_data, array=array)
         self.main_line = None
-        self.id = 'Unregistered'
+        self.id = "Unregistered"
         self.md_pl_choke = None
         self.is_choke = True
         self.ramp = None
@@ -32,7 +32,11 @@ class ChokeArea(Polygon):
 
     @property
     def corner_walloff(self):
-        return sorted(list(self.points), key=lambda x: x.distance_to_point2(self.center), reverse=True)[:2]
+        return sorted(
+            list(self.points),
+            key=lambda x: x.distance_to_point2(self.center),
+            reverse=True,
+        )[:2]
 
     @lru_cache()
     def same_height(self, p1, p2):
@@ -47,7 +51,9 @@ class RawChoke(ChokeArea):
     Chokes found in the C extension where the terrain generates a choke point
     """
 
-    def __init__(self, array: np.ndarray, map_data: "MapData", raw_choke: CMapChoke) -> None:
+    def __init__(
+        self, array: np.ndarray, map_data: "MapData", raw_choke: CMapChoke
+    ) -> None:
         super().__init__(map_data=map_data, array=array)
 
         self.main_line = raw_choke.main_line
@@ -86,7 +92,7 @@ class MDRamp(ChokeArea):
         next_point = current.rounded
         while next_point in self.points:
             side_a = next_point
-            current = current.offset(perpendicular_dir*step_size)
+            current = current.offset(perpendicular_dir * step_size)
             next_point = current.rounded
 
         self.side_a = side_a
@@ -103,14 +109,22 @@ class MDRamp(ChokeArea):
 
     @property
     def corner_walloff(self):
-        raw_points = sorted(list(self.points), key=lambda x: x.distance_to_point2(self.bottom_center), reverse=True)[:2]
+        raw_points = sorted(
+            list(self.points),
+            key=lambda x: x.distance_to_point2(self.bottom_center),
+            reverse=True,
+        )[:2]
         offset_points = [p.offset(self.offset) for p in raw_points]
         offset_points.extend(raw_points)
         return offset_points
 
     @property
     def middle_walloff_depot(self):
-        raw_points = sorted(list(self.points), key=lambda x: x.distance_to_point2(self.bottom_center), reverse=True)
+        raw_points = sorted(
+            list(self.points),
+            key=lambda x: x.distance_to_point2(self.bottom_center),
+            reverse=True,
+        )
         # TODO  its white board time,  need to figure out some geometric intuition here
         dist = self.map_data.distance(raw_points[0], raw_points[1])
         r = dist ** 0.5
@@ -129,8 +143,13 @@ class MDRamp(ChokeArea):
         Will return the closest region with respect to self
 
         """
-        return min(region_list,
-                   key=lambda area: min(self.map_data.distance(area.center, point) for point in self.outer_perimeter_points))
+        return min(
+            region_list,
+            key=lambda area: min(
+                self.map_data.distance(area.center, point)
+                for point in self.outer_perimeter_points
+            ),
+        )
 
     def set_regions(self):
         """
@@ -142,6 +161,7 @@ class MDRamp(ChokeArea):
 
         """
         from MapAnalyzer.Region import Region
+
         for p in self.outer_perimeter_points:
             areas = self.map_data.where_all(p)
             for area in areas:
@@ -166,7 +186,7 @@ class MDRamp(ChokeArea):
             region_list = list(self.map_data.regions.values())
             region_list.remove(self.regions[0])
             closest_region = self.closest_region(region_list=region_list)
-            assert (closest_region not in self.regions)
+            assert closest_region not in self.regions
             self.areas.append(closest_region)
 
     @property
@@ -223,14 +243,20 @@ class VisionBlockerArea(ChokeArea):
         org = self.top
         pts = [self.bottom, self.right, self.left]
         res = self.map_data.closest_towards_point(points=pts, target=org)
-        self.side_a = int(round((res[0] + org[0]) / 2)), int(round((res[1] + org[1]) / 2))
+        self.side_a = int(round((res[0] + org[0]) / 2)), int(
+            round((res[1] + org[1]) / 2)
+        )
         if res != self.bottom:
             org = self.bottom
             pts = [self.top, self.right, self.left]
             res = self.map_data.closest_towards_point(points=pts, target=org)
-            self.side_b = int(round((res[0] + org[0]) / 2)), int(round((res[1] + org[1]) / 2))
+            self.side_b = int(round((res[0] + org[0]) / 2)), int(
+                round((res[1] + org[1]) / 2)
+            )
         else:
-            self.side_b = int(round((self.right[0] + self.left[0]) / 2)), int(round((self.right[1] + self.left[1]) / 2))
+            self.side_b = int(round((self.right[0] + self.left[0]) / 2)), int(
+                round((self.right[1] + self.left[1]) / 2)
+            )
 
     def __repr__(self):  # pragma: no cover
         return f"<VisionBlockerArea[size={self.area}]: {self.regions}>"

--- a/MapAnalyzer/constructs.py
+++ b/MapAnalyzer/constructs.py
@@ -160,6 +160,28 @@ class MDRamp(ChokeArea):
              Make this a private method
 
         """
+        from MapAnalyzer.Region import Region
+
+        for p in self.outer_perimeter_points:
+            areas = self.map_data.where_all(p)
+            for area in areas:
+                # edge case  = its a VisionBlockerArea (and also on the perimeter) so we grab the touching Regions
+                if isinstance(area, VisionBlockerArea):
+                    for sub_area in area.areas:
+                        # add it to our Areas
+                        if isinstance(sub_area, Region) and sub_area not in self.areas:
+                            self.areas.append(sub_area)
+                        # add ourselves to it's Areas
+                        if isinstance(sub_area, Region) and self not in sub_area.areas:
+                            sub_area.areas.append(self)
+
+                # standard case
+                if isinstance(area, Region) and area not in self.areas:
+                    self.areas.append(area)
+                    # add ourselves to the Region Area's
+                if isinstance(area, Region) and self not in area.areas:
+                    area.areas.append(self)
+
         if len(self.regions) < 2:
             region_list = list(self.map_data.regions.values())
             region_list.remove(self.regions[0])

--- a/MapAnalyzer/decorators.py
+++ b/MapAnalyzer/decorators.py
@@ -12,6 +12,7 @@ from tqdm.contrib import DummyTqdmFile
 
 tqdm = partial(std_tqdm, dynamic_ncols=True)
 
+
 def logger_wraps(*, entry=True, exit=True, level="INFO"):
     def wrapper(func):
         name = func.__name__
@@ -20,7 +21,9 @@ def logger_wraps(*, entry=True, exit=True, level="INFO"):
         def wrapped(*args, **kwargs):
             logger_ = logger.opt(depth=1)
             if entry:
-                logger_.log(level, "Entering '{}' (args={}, kwargs={})", name, args, kwargs)
+                logger_.log(
+                    level, "Entering '{}' (args={}, kwargs={})", name, args, kwargs
+                )
             result = func(*args, **kwargs)
             if exit:
                 logger_.log(level, "Exiting '{}' (result={})", name, result)
@@ -45,9 +48,14 @@ def std_out_err_redirect_tqdm():
         sys.stdout, sys.stderr = orig_out_err
 
 
-def provide_progress_bar(function: Callable, estimated_time: int, tstep: float = 0.2,
-                         tqdm_kwargs: Optional[Dict[str, str]] = None, args: Optional[Tuple["MapData"]] = None,
-                         kwargs: Optional[Dict[Any, Any]] = None) -> None:
+def provide_progress_bar(
+    function: Callable,
+    estimated_time: int,
+    tstep: float = 0.2,
+    tqdm_kwargs: Optional[Dict[str, str]] = None,
+    args: Optional[Tuple["MapData"]] = None,
+    kwargs: Optional[Dict[Any, Any]] = None,
+) -> None:
     """Tqdm wrapper for a long-running function
     args:
         function - function to run
@@ -72,7 +80,9 @@ def provide_progress_bar(function: Callable, estimated_time: int, tstep: float =
     def myrunner(func, ret_val, *r_args, **r_kwargs):
         ret_val[0] = func(*r_args, **r_kwargs)
 
-    thread = threading.Thread(target=myrunner, args=(function, ret) + tuple(args), kwargs=kwargs)
+    thread = threading.Thread(
+        target=myrunner, args=(function, ret) + tuple(args), kwargs=kwargs
+    )
     pbar = tqdm(total=estimated_time, **tqdm_kwargs)
     thread.start()
     while thread.is_alive():
@@ -82,8 +92,12 @@ def provide_progress_bar(function: Callable, estimated_time: int, tstep: float =
     return ret[0]
 
 
-def progress_wrapped(estimated_time: int, desc: str = "Progress", tstep: float = 0.2,
-                     tqdm_kwargs: None = None) -> Callable:
+def progress_wrapped(
+    estimated_time: int,
+    desc: str = "Progress",
+    tstep: float = 0.2,
+    tqdm_kwargs: None = None,
+) -> Callable:
     """Decorate a function to add a progress bar"""
 
     if tqdm_kwargs is None:
@@ -93,9 +107,15 @@ def progress_wrapped(estimated_time: int, desc: str = "Progress", tstep: float =
     def real_decorator(function):
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
-            tqdm_kwargs['desc'] = desc
-            return provide_progress_bar(function, estimated_time=estimated_time, tstep=tstep, tqdm_kwargs=tqdm_kwargs,
-                                        args=args, kwargs=kwargs)
+            tqdm_kwargs["desc"] = desc
+            return provide_progress_bar(
+                function,
+                estimated_time=estimated_time,
+                tstep=tstep,
+                tqdm_kwargs=tqdm_kwargs,
+                args=args,
+                kwargs=kwargs,
+            )
 
         return wrapper
 

--- a/MapAnalyzer/destructibles.py
+++ b/MapAnalyzer/destructibles.py
@@ -4,80 +4,77 @@ https://github.com/DrInfy/sharpy-sc2/blob/develop/sharpy/managers/unit_value.py
 from sc2.ids.unit_typeid import UnitTypeId
 
 buildings_2x2 = {
-        UnitTypeId.SUPPLYDEPOT,
-        UnitTypeId.PYLON,
-        UnitTypeId.DARKSHRINE,
-        UnitTypeId.PHOTONCANNON,
-        UnitTypeId.SHIELDBATTERY,
-        UnitTypeId.TECHLAB,
-        UnitTypeId.STARPORTTECHLAB,
-        UnitTypeId.FACTORYTECHLAB,
-        UnitTypeId.BARRACKSTECHLAB,
-        UnitTypeId.REACTOR,
-        UnitTypeId.STARPORTREACTOR,
-        UnitTypeId.FACTORYREACTOR,
-        UnitTypeId.BARRACKSREACTOR,
-        UnitTypeId.MISSILETURRET,
-        UnitTypeId.SPORECRAWLER,
-        UnitTypeId.SPIRE,
-        UnitTypeId.GREATERSPIRE,
-        UnitTypeId.SPINECRAWLER,
+    UnitTypeId.SUPPLYDEPOT,
+    UnitTypeId.PYLON,
+    UnitTypeId.DARKSHRINE,
+    UnitTypeId.PHOTONCANNON,
+    UnitTypeId.SHIELDBATTERY,
+    UnitTypeId.TECHLAB,
+    UnitTypeId.STARPORTTECHLAB,
+    UnitTypeId.FACTORYTECHLAB,
+    UnitTypeId.BARRACKSTECHLAB,
+    UnitTypeId.REACTOR,
+    UnitTypeId.STARPORTREACTOR,
+    UnitTypeId.FACTORYREACTOR,
+    UnitTypeId.BARRACKSREACTOR,
+    UnitTypeId.MISSILETURRET,
+    UnitTypeId.SPORECRAWLER,
+    UnitTypeId.SPIRE,
+    UnitTypeId.GREATERSPIRE,
+    UnitTypeId.SPINECRAWLER,
 }
 
 buildings_3x3 = {
-        UnitTypeId.GATEWAY,
-        UnitTypeId.WARPGATE,
-        UnitTypeId.CYBERNETICSCORE,
-        UnitTypeId.FORGE,
-        UnitTypeId.ROBOTICSFACILITY,
-        UnitTypeId.ROBOTICSBAY,
-        UnitTypeId.TEMPLARARCHIVE,
-        UnitTypeId.TWILIGHTCOUNCIL,
-        UnitTypeId.TEMPLARARCHIVE,
-        UnitTypeId.STARGATE,
-        UnitTypeId.FLEETBEACON,
-        UnitTypeId.ASSIMILATOR,
-        UnitTypeId.ASSIMILATORRICH,
-        UnitTypeId.SPAWNINGPOOL,
-        UnitTypeId.ROACHWARREN,
-        UnitTypeId.HYDRALISKDEN,
-        UnitTypeId.BANELINGNEST,
-        UnitTypeId.EVOLUTIONCHAMBER,
-        UnitTypeId.NYDUSNETWORK,
-        UnitTypeId.NYDUSCANAL,
-        UnitTypeId.EXTRACTOR,
-        UnitTypeId.EXTRACTORRICH,
-        UnitTypeId.INFESTATIONPIT,
-        UnitTypeId.ULTRALISKCAVERN,
-        UnitTypeId.BARRACKS,
-        UnitTypeId.ENGINEERINGBAY,
-        UnitTypeId.FACTORY,
-        UnitTypeId.GHOSTACADEMY,
-        UnitTypeId.STARPORT,
-        UnitTypeId.FUSIONREACTOR,
-        UnitTypeId.BUNKER,
-        UnitTypeId.ARMORY,
-        UnitTypeId.REFINERY,
-        UnitTypeId.REFINERYRICH,
+    UnitTypeId.GATEWAY,
+    UnitTypeId.WARPGATE,
+    UnitTypeId.CYBERNETICSCORE,
+    UnitTypeId.FORGE,
+    UnitTypeId.ROBOTICSFACILITY,
+    UnitTypeId.ROBOTICSBAY,
+    UnitTypeId.TEMPLARARCHIVE,
+    UnitTypeId.TWILIGHTCOUNCIL,
+    UnitTypeId.TEMPLARARCHIVE,
+    UnitTypeId.STARGATE,
+    UnitTypeId.FLEETBEACON,
+    UnitTypeId.ASSIMILATOR,
+    UnitTypeId.ASSIMILATORRICH,
+    UnitTypeId.SPAWNINGPOOL,
+    UnitTypeId.ROACHWARREN,
+    UnitTypeId.HYDRALISKDEN,
+    UnitTypeId.BANELINGNEST,
+    UnitTypeId.EVOLUTIONCHAMBER,
+    UnitTypeId.NYDUSNETWORK,
+    UnitTypeId.NYDUSCANAL,
+    UnitTypeId.EXTRACTOR,
+    UnitTypeId.EXTRACTORRICH,
+    UnitTypeId.INFESTATIONPIT,
+    UnitTypeId.ULTRALISKCAVERN,
+    UnitTypeId.BARRACKS,
+    UnitTypeId.ENGINEERINGBAY,
+    UnitTypeId.FACTORY,
+    UnitTypeId.GHOSTACADEMY,
+    UnitTypeId.STARPORT,
+    UnitTypeId.FUSIONREACTOR,
+    UnitTypeId.BUNKER,
+    UnitTypeId.ARMORY,
+    UnitTypeId.REFINERY,
+    UnitTypeId.REFINERYRICH,
 }
 
 buildings_5x5 = {
-        UnitTypeId.NEXUS,
-        UnitTypeId.HATCHERY,
-        UnitTypeId.HIVE,
-        UnitTypeId.LAIR,
-        UnitTypeId.COMMANDCENTER,
-        UnitTypeId.ORBITALCOMMAND,
-        UnitTypeId.PLANETARYFORTRESS,
+    UnitTypeId.NEXUS,
+    UnitTypeId.HATCHERY,
+    UnitTypeId.HIVE,
+    UnitTypeId.LAIR,
+    UnitTypeId.COMMANDCENTER,
+    UnitTypeId.ORBITALCOMMAND,
+    UnitTypeId.PLANETARYFORTRESS,
 }
 
 BUILDING_IDS = buildings_5x5.union(buildings_3x3).union(buildings_2x2)
 
 
-destructable_2x2 = {
-    UnitTypeId.ROCKS2X2NONCONJOINED,
-    UnitTypeId.DEBRIS2X2NONCONJOINED
-}
+destructable_2x2 = {UnitTypeId.ROCKS2X2NONCONJOINED, UnitTypeId.DEBRIS2X2NONCONJOINED}
 
 destructable_4x4 = {
     UnitTypeId.DESTRUCTIBLECITYDEBRIS4X4,
@@ -117,12 +114,12 @@ destructable_2x6 = {
 
 destructable_4x12 = {
     UnitTypeId.DESTRUCTIBLEROCKEX1VERTICALHUGE,
-    UnitTypeId.DESTRUCTIBLEICEVERTICALHUGE
+    UnitTypeId.DESTRUCTIBLEICEVERTICALHUGE,
 }
 
 destructable_12x4 = {
     UnitTypeId.DESTRUCTIBLEROCKEX1HORIZONTALHUGE,
-    UnitTypeId.DESTRUCTIBLEICEHORIZONTALHUGE
+    UnitTypeId.DESTRUCTIBLEICEHORIZONTALHUGE,
 }
 
 destructable_6x6 = {

--- a/MapAnalyzer/exceptions.py
+++ b/MapAnalyzer/exceptions.py
@@ -7,8 +7,10 @@ class CustomDeprecationWarning(BaseException):
         self.new = newarg
 
     def __str__(self) -> str:
-        return f"[DeprecationWarning] Passing `{self.old}` argument is deprecated," \
-               f" and will have no effect,\nUse `{self.new}` instead"
+        return (
+            f"[DeprecationWarning] Passing `{self.old}` argument is deprecated,"
+            f" and will have no effect,\nUse `{self.new}` instead"
+        )
 
 
 class PatherNoPointsException(BaseException):
@@ -18,9 +20,11 @@ class PatherNoPointsException(BaseException):
         self.goal = goal
 
     def __str__(self) -> str:
-        return f"[PatherNoPointsException]" \
-            f"\nExpected: Start (pointlike), Goal (pointlike)," \
+        return (
+            f"[PatherNoPointsException]"
+            f"\nExpected: Start (pointlike), Goal (pointlike),"
             f"\nGot: Start {self.start}, Goal {self.goal}."
+        )
 
 
 class OutOfBoundsException(BaseException):

--- a/MapAnalyzer/utils.py
+++ b/MapAnalyzer/utils.py
@@ -35,43 +35,43 @@ def change_destructable_status_in_grid(grid: np.ndarray, unit: Unit, status: int
     if name == "MineralField450":
         x = int(pos[0]) - 1
         y = int(pos[1])
-        grid[x:(x + 2), y] = status
+        grid[x : (x + 2), y] = status
     elif type_id in destructable_2x2:
         w = 2
         h = 2
-        x = int(pos[0] - w/2)
-        y = int(pos[1] - h/2)
-        grid[x:(x + w), y:(y + h)] = status
+        x = int(pos[0] - w / 2)
+        y = int(pos[1] - h / 2)
+        grid[x : (x + w), y : (y + h)] = status
     elif type_id in destructable_2x4:
         w = 2
         h = 4
         x = int(pos[0] - w / 2)
         y = int(pos[1] - h / 2)
-        grid[x:(x + w), y:(y + h)] = status
+        grid[x : (x + w), y : (y + h)] = status
     elif type_id in destructable_2x6:
         w = 2
         h = 6
         x = int(pos[0] - w / 2)
         y = int(pos[1] - h / 2)
-        grid[x:(x + w), y:(y + h)] = status
+        grid[x : (x + w), y : (y + h)] = status
     elif type_id in destructable_4x2:
         w = 4
         h = 2
         x = int(pos[0] - w / 2)
         y = int(pos[1] - h / 2)
-        grid[x:(x + w), y:(y + h)] = status
+        grid[x : (x + w), y : (y + h)] = status
     elif type_id in destructable_4x4:
         w = 4
         h = 4
         x = int(pos[0] - w / 2)
         y = int(pos[1] - h / 2)
-        grid[x:(x + w), y:(y + h)] = status
+        grid[x : (x + w), y : (y + h)] = status
     elif type_id in destructable_6x2:
         w = 6
         h = 2
         x = int(pos[0] - w / 2)
         y = int(pos[1] - h / 2)
-        grid[x:(x + w), y:(y + h)] = status
+        grid[x : (x + w), y : (y + h)] = status
     elif type_id in destructable_6x6:
         # for some reason on some maps like death aura
         # these rocks have a bit weird sizes
@@ -82,47 +82,48 @@ def change_destructable_status_in_grid(grid: np.ndarray, unit: Unit, status: int
         h = 6
         x = int(pos[0] - w / 2)
         y = int(pos[1] - h / 2)
-        grid[x:(x + w), (y + 1):(y + h - 1)] = status
-        grid[(x + 1):(x + w - 1), y:(y + h)] = status
+        grid[x : (x + w), (y + 1) : (y + h - 1)] = status
+        grid[(x + 1) : (x + w - 1), y : (y + h)] = status
     elif type_id in destructable_12x4:
         w = 12
         h = 4
         x = int(pos[0] - w / 2)
         y = int(pos[1] - h / 2)
-        grid[x:(x + w), y:(y + h)] = status
+        grid[x : (x + w), y : (y + h)] = status
     elif type_id in destructable_4x12:
         w = 4
         h = 12
         x = int(pos[0] - w / 2)
         y = int(pos[1] - h / 2)
-        grid[x:(x + w), y:(y + h)] = status
+        grid[x : (x + w), y : (y + h)] = status
     elif type_id in destructable_BLUR:
         x_ref = int(pos[0] - 5)
         y_pos = int(pos[1])
-        grid[(x_ref + 6):(x_ref + 6 + 2), y_pos + 4] = status
-        grid[(x_ref + 5):(x_ref + 5 + 4), y_pos + 3] = status
-        grid[(x_ref + 4):(x_ref + 4 + 6), y_pos + 2] = status
-        grid[(x_ref + 3):(x_ref + 3 + 7), y_pos + 1] = status
-        grid[(x_ref + 2):(x_ref + 2 + 7), y_pos] = status
-        grid[(x_ref + 1):(x_ref + 1 + 7), y_pos - 1] = status
-        grid[(x_ref + 0):(x_ref + 0 + 7), y_pos - 2] = status
-        grid[(x_ref + 0):(x_ref + 0 + 6), y_pos - 3] = status
-        grid[(x_ref + 1):(x_ref + 1 + 4), y_pos - 4] = status
-        grid[(x_ref + 2):(x_ref + 2 + 2), y_pos - 5] = status
+        grid[(x_ref + 6) : (x_ref + 6 + 2), y_pos + 4] = status
+        grid[(x_ref + 5) : (x_ref + 5 + 4), y_pos + 3] = status
+        grid[(x_ref + 4) : (x_ref + 4 + 6), y_pos + 2] = status
+        grid[(x_ref + 3) : (x_ref + 3 + 7), y_pos + 1] = status
+        grid[(x_ref + 2) : (x_ref + 2 + 7), y_pos] = status
+        grid[(x_ref + 1) : (x_ref + 1 + 7), y_pos - 1] = status
+        grid[(x_ref + 0) : (x_ref + 0 + 7), y_pos - 2] = status
+        grid[(x_ref + 0) : (x_ref + 0 + 6), y_pos - 3] = status
+        grid[(x_ref + 1) : (x_ref + 1 + 4), y_pos - 4] = status
+        grid[(x_ref + 2) : (x_ref + 2 + 2), y_pos - 5] = status
 
     elif type_id in destructable_ULBR:
         x_ref = int(pos[0] - 5)
         y_pos = int(pos[1])
-        grid[(x_ref + 6):(x_ref + 6 + 2), y_pos - 5] = status
-        grid[(x_ref + 5):(x_ref + 5 + 4), y_pos - 4] = status
-        grid[(x_ref + 4):(x_ref + 4 + 6), y_pos - 3] = status
-        grid[(x_ref + 3):(x_ref + 3 + 7), y_pos - 2] = status
-        grid[(x_ref + 2):(x_ref + 2 + 7), y_pos - 1] = status
-        grid[(x_ref + 1):(x_ref + 1 + 7), y_pos] = status
-        grid[(x_ref + 0):(x_ref + 0 + 7), y_pos + 1] = status
-        grid[(x_ref + 0):(x_ref + 0 + 6), y_pos + 2] = status
-        grid[(x_ref + 1):(x_ref + 1 + 4), y_pos + 3] = status
-        grid[(x_ref + 2):(x_ref + 2 + 2), y_pos + 4] = status
+        grid[(x_ref + 6) : (x_ref + 6 + 2), y_pos - 5] = status
+        grid[(x_ref + 5) : (x_ref + 5 + 4), y_pos - 4] = status
+        grid[(x_ref + 4) : (x_ref + 4 + 6), y_pos - 3] = status
+        grid[(x_ref + 3) : (x_ref + 3 + 7), y_pos - 2] = status
+        grid[(x_ref + 2) : (x_ref + 2 + 7), y_pos - 1] = status
+        grid[(x_ref + 1) : (x_ref + 1 + 7), y_pos] = status
+        grid[(x_ref + 0) : (x_ref + 0 + 7), y_pos + 1] = status
+        grid[(x_ref + 0) : (x_ref + 0 + 6), y_pos + 2] = status
+        grid[(x_ref + 1) : (x_ref + 1 + 4), y_pos + 3] = status
+        grid[(x_ref + 2) : (x_ref + 2 + 2), y_pos + 4] = status
+
 
 def fix_map_ramps(bot: BotAI):
     """
@@ -136,7 +137,9 @@ def fix_map_ramps(bot: BotAI):
     pathing = np.ndenumerate(pathing_grid.T)
 
     def equal_height_around(tile):
-        sliced = bot.game_info.terrain_height.data_numpy[tile[1] - 1: tile[1] + 2, tile[0] - 1: tile[0] + 2]
+        sliced = bot.game_info.terrain_height.data_numpy[
+            tile[1] - 1 : tile[1] + 2, tile[0] - 1 : tile[0] + 2
+        ]
         return len(np.unique(sliced)) == 1
 
     map_area = bot.game_info.playable_area
@@ -144,19 +147,23 @@ def fix_map_ramps(bot: BotAI):
         Point2((a, b))
         for (b, a), value in pathing
         if value == 1
-           and map_area.x <= a < map_area.x + map_area.width
-           and map_area.y <= b < map_area.y + map_area.height
-           and bot.game_info.placement_grid[(a, b)] == 0
+        and map_area.x <= a < map_area.x + map_area.width
+        and map_area.y <= b < map_area.y + map_area.height
+        and bot.game_info.placement_grid[(a, b)] == 0
     ]
     ramp_points = [point for point in points if not equal_height_around(point)]
     vision_blockers = set(point for point in points if equal_height_around(point))
-    ramps = [Ramp(group, bot.game_info) for group in bot.game_info._find_groups(ramp_points)]
+    ramps = [
+        Ramp(group, bot.game_info) for group in bot.game_info._find_groups(ramp_points)
+    ]
     return ramps, vision_blockers
 
 
-def get_sets_with_mutual_elements(list_mdchokes: List[CMapChoke],
-                                  area: Optional[Union[MDRamp, VisionBlockerArea]] = None,
-                                  base_choke: CMapChoke = None) -> List[int]:
+def get_sets_with_mutual_elements(
+    list_mdchokes: List[CMapChoke],
+    area: Optional[Union[MDRamp, VisionBlockerArea]] = None,
+    base_choke: CMapChoke = None,
+) -> List[int]:
     li = []
     if area:
         s1 = area.points
@@ -165,13 +172,14 @@ def get_sets_with_mutual_elements(list_mdchokes: List[CMapChoke],
     for c in list_mdchokes:
         s2 = c.pixels
         s3 = s1 ^ s2
-        if len(s3) <= 0.95*(len(s1) + len(s2)):
+        if len(s3) <= 0.95 * (len(s1) + len(s2)):
             li.append(c.id)
     return li
 
 
 def mock_map_data(map_file: str) -> "MapData":
     from MapAnalyzer.MapData import MapData
+
     with lzma.open(f"{map_file}", "rb") as f:
         raw_game_data, raw_game_info, raw_observation = pickle.load(f)
 
@@ -180,9 +188,9 @@ def mock_map_data(map_file: str) -> "MapData":
 
 
 def import_bot_instance(
-        raw_game_data: Response,
-        raw_game_info: Response,
-        raw_observation: ResponseObservation,
+    raw_game_data: Response,
+    raw_game_info: Response,
+    raw_observation: ResponseObservation,
 ) -> BotAI:
     """
     import_bot_instance DocString
@@ -195,7 +203,7 @@ def import_bot_instance(
     bot._initialize_variables()
     # noinspection PyProtectedMember
     bot._prepare_start(
-            client=None, player_id=1, game_info=game_info, game_data=game_data
+        client=None, player_id=1, game_info=game_info, game_data=game_data
     )
     # noinspection PyProtectedMember
     bot._prepare_first_step()


### PR DESCRIPTION
No rush to merge this, feedback is appreciated. These changes are currently live in Dysnomia on aiarena ladder

`MapData._compile_map` 
|Map |Speedup|
--- | --- |
|2000AtmospheresAIE|3.996|
|BerlingradAIE|2.51|
|BlackburnAIE|3.536|
|CuriousMindsAIE|2.88|
|GlitteringAshesAIE|2.73|
|HardwireAIE|2.937|

Main improvement was found while calculating `Polygon` areas, which was previously calling `MapData.where_all` for every point on the perimeter and then checking if that point was inside any other choke or region etc
There is now an `extended_array_matrix` which contains the arrays for every `Polygon` created, using this we can check if a `Polygon''s perimeter points exist in other polygons in one operation.

Removed other blocks of code that looked like it was repeating this process of looking for subareas in earlier steps of the compile procedure. Please check this over, not sure if something was overlooked

Found another bottleneck while `Regions` were calculated, this was since it iterated all points and created a `Point2` for each one before working out the area. This is replaced with a quick call to `np.sum()` all the ones in the array